### PR TITLE
Add HALSER to product navigation

### DIFF
--- a/content/en/halser/_index.md
+++ b/content/en/halser/_index.md
@@ -1,0 +1,7 @@
+---
+title: HALSER
+weight: 450
+manualLink: https://docs.hatlabs.fi/halser/
+---
+
+https://docs.hatlabs.fi/halser/


### PR DESCRIPTION
## Summary

- Add HALSER link to the docs landing page sidebar, pointing to https://docs.hatlabs.fi/halser/
- Placed between HALMET and HALPI in navigation order (weight 450)

🤖 Generated with [Claude Code](https://claude.com/claude-code)